### PR TITLE
Correct cache.item.account to cache.account

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -99,7 +99,7 @@ server.pack.register(require('../'), function (err) {
                     return callback(null, false);
                 }
 
-                return callback(null, true, cached.item.account)
+                return callback(null, true, cached.account)
             })
         }
     });


### PR DESCRIPTION
The example is not working. 

`cache.item` is undefined because we are using the 2nd parameter of the callback passed to `cache.get` (which is the cached value itself). 

It would be `cache.item.account` if we were using the 3rd argument.
