### PR TITLE
Fix clearInvalid (for issue #34)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,7 +36,8 @@ internals.implementation = function (server, options) {
         password: settings.password,
         isSecure: settings.isSecure !== false,                  // Defaults to true
         path: '/',
-        isHttpOnly: settings.isHttpOnly !== false               // Defaults to true
+        isHttpOnly: settings.isHttpOnly !== false,              // Defaults to true
+        clearInvalid: settings.clearInvalid
     };
 
     if (settings.ttl) {
@@ -180,4 +181,3 @@ internals.implementation = function (server, options) {
 
     return scheme;
 };
-

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hapi-auth-cookie",
   "description": "Cookie authentication plugin",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "repository": "git://github.com/hapijs/hapi-auth-cookie",
   "main": "index",
   "keywords": [

--- a/test/index.js
+++ b/test/index.js
@@ -1359,4 +1359,113 @@ describe('scheme', function () {
             });
         });
     });
+
+    it('clear cookie on invalid', function (done) {
+
+        var server = new Hapi.Server();
+        server.pack.register(require('../'), function (err) {
+
+            expect(err).to.not.exist();
+
+            server.auth.strategy('default', 'cookie', true, {
+                password: 'password1',
+                ttl: 60 * 1000,
+                domain: 'example.com',
+                cookie: 'special',
+                clearInvalid: true,
+                validateFunc: function (session, callback) {
+
+                    var override = Hoek.clone(session);
+                    override.something = 'new';
+
+                    return callback(null, session.user === 'valid', override);
+                }
+            });
+
+            server.route({
+                method: 'GET', path: '/login/{user}',
+                config: {
+                    auth: { mode: 'try' },
+                    handler: function (request, reply) {
+
+                        request.auth.session.set({ user: request.params.user });
+                        return reply(request.params.user);
+                    }
+                }
+            });
+
+            server.route({
+                method: 'GET', path: '/resource', handler: function (request, reply) {
+
+                    expect(request.auth.credentials.something).to.equal('new');
+                    return reply('resource');
+                }
+            });
+
+            server.inject('/login/valid', function (res) {
+
+                expect(res.result).to.equal('valid');
+                var header = res.headers['set-cookie'];
+                expect(header.length).to.equal(1);
+                expect(header[0]).to.contain('Max-Age=60');
+                var cookie = header[0].match(/(?:[^\x00-\x20\(\)<>@\,;\:\\"\/\[\]\?\=\{\}\x7F]+)\s*=\s*(?:([^\x00-\x20\"\,\;\\\x7F]*))/);
+
+                // kill the server, and create a new one, then use the saved cookie
+                // and see if it gets unset
+                server.stop(function(){
+
+                var server2 = new Hapi.Server();
+                server2.pack.register(require('../'), function (err) {
+
+                    server2.auth.strategy('default', 'cookie', true, {
+                        password: 'password2',
+                        ttl: 60 * 1000,
+                        domain: 'example.com',
+                        cookie: 'special',
+                        clearInvalid: true,
+                        validateFunc: function (session, callback) {
+
+                            var override = Hoek.clone(session);
+                            override.something = 'new';
+
+                            return callback(null, session.user === 'valid', override);
+                        }
+                    });
+
+                    server2.route({
+                        method: 'GET', path: '/login/{user}',
+                        config: {
+                            auth: { mode: 'try' },
+                            handler: function (request, reply) {
+
+                                request.auth.session.set({ user: request.params.user });
+                                return reply(request.params.user);
+                            }
+                        }
+                    });
+
+                    server2.route({
+                        method: 'GET', path: '/resource', handler: function (request, reply) {
+
+                            expect(request.auth.credentials.something).to.equal('new');
+                            return reply('resource');
+                        }
+                    });
+
+                    server2.inject({ method: 'GET', url: '/resource', headers: { cookie: 'special=' + cookie[1] } }, function(res) {
+
+                        expect(JSON.stringify(res.result)).to.equal('{"statusCode":400,"error":"Bad Request","message":"Bad cookie value: special"}');
+                        var header = res.headers['set-cookie'];
+                        expect(header.length).to.equal(1);
+                        expect(header[0]).to.contain('Max-Age=0');
+                        expect(header[0]).to.contain('Expires=');
+                        expect(header[0]).to.contain('special=;');
+
+                        done();
+                    });
+                });
+                });
+            });
+        });
+    });
 });


### PR DESCRIPTION
This adds a test case for clearInvalid cookie code when you change the password between server restarts (or in the case of the test a 2nd server is created) and fixes the code to properly pass the configuration value on to the internal clone.  Also bumped the version number to cover the change.
