### PR TITLE
Remove old repository name

### DIFF
--- a/API.md
+++ b/API.md
@@ -31,7 +31,7 @@ The `'cookie`' scheme takes the following options:
   current session for a new `ttl` duration. Defaults to `false`.
 - `redirectTo` - optional login URI or function `function(request)` that returns a URI to redirect unauthenticated requests to. Note that it will only
   trigger when the authentication mode is `'required'`. To enable or disable redirections for a specific route,
-  set the route `plugins` config (`{ options: { plugins: { 'hapi-auth-cookie': { redirectTo: false } } } }`).
+  set the route `plugins` config (`{ options: { plugins: { cookie: { redirectTo: false } } } }`).
   Defaults to no redirection.
 - `appendNext` - if `redirectTo` is `true`, can be a boolean, string, or object. Defaults to `false`.
     - if set to `true`, a string, or an object, appends the current request path to the query component
@@ -175,7 +175,7 @@ internals.server = async function () {
                     mode: 'try'
                 },
                 plugins: {
-                    'hapi-auth-cookie': {
+                    cookie: {
                         redirectTo: false
                     }
                 },

--- a/example/index.js
+++ b/example/index.js
@@ -115,9 +115,35 @@ internals.start = async function () {
     server.auth.default('session');
 
     server.route([
-        { method: 'GET', path: '/', config: { handler: internals.home } },
-        { method: ['GET', 'POST'], path: '/login', config: { handler: internals.login, auth: { mode: 'try' }, plugins: { cookie: { redirectTo: false } } } },
-        { method: 'GET', path: '/logout', config: { handler: internals.logout } }
+        {
+            method: 'GET',
+            path: '/',
+            options: {
+                handler: internals.home
+            }
+        },
+        {
+            method: ['GET', 'POST'],
+            path: '/login',
+            options: {
+                handler: internals.login,
+                auth: {
+                    mode: 'try'
+                },
+                plugins: {
+                    cookie: {
+                        redirectTo: false
+                    }
+                }
+            }
+        },
+        {
+            method: 'GET',
+            path: '/logout',
+            options: {
+                handler: internals.logout
+            }
+        }
     ]);
 
     await server.start();

--- a/example/index.js
+++ b/example/index.js
@@ -116,7 +116,7 @@ internals.start = async function () {
 
     server.route([
         { method: 'GET', path: '/', config: { handler: internals.home } },
-        { method: ['GET', 'POST'], path: '/login', config: { handler: internals.login, auth: { mode: 'try' }, plugins: { 'hapi-auth-cookie': { redirectTo: false } } } },
+        { method: ['GET', 'POST'], path: '/login', config: { handler: internals.login, auth: { mode: 'try' }, plugins: { cookie: { redirectTo: false } } } },
         { method: 'GET', path: '/logout', config: { handler: internals.logout } }
     ]);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -196,10 +196,10 @@ internals.implementation = (server, options) => {
             const unauthenticated = (err, result) => {
 
                 let redirectTo = settings.redirectTo;
-                if (request.route.settings.plugins['hapi-auth-cookie'] &&
-                    request.route.settings.plugins['hapi-auth-cookie'].redirectTo !== undefined) {
+                if (request.route.settings.plugins.cookie &&
+                    request.route.settings.plugins.cookie.redirectTo !== undefined) {
 
-                    redirectTo = request.route.settings.plugins['hapi-auth-cookie'].redirectTo;
+                    redirectTo = request.route.settings.plugins.cookie.redirectTo;
                 }
 
                 let uri = typeof redirectTo === 'function' ? redirectTo(request) : redirectTo;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@hapi/cookie",
   "description": "Cookie authentication plugin",
   "version": "11.0.2",
-  "repository": "git://github.com/hapijs/hapi-auth-cookie",
+  "repository": "git://github.com/hapijs/cookie",
   "main": "lib/index.js",
   "files": [
     "lib"

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -5,7 +5,7 @@ exports.loginWithResourceEndpoint = (server) => {
 
     server.route({
         method: 'GET', path: '/login/{user}',
-        config: {
+        options: {
             auth: { mode: 'try' },
             handler: function (request, h) {
 

--- a/test/index.js
+++ b/test/index.js
@@ -1241,7 +1241,7 @@ describe('scheme', () => {
                 path: '/',
                 options: {
                     plugins: {
-                        'hapi-auth-cookie': {}
+                        cookie: {}
                     },
                     handler: function (request, h) {
 
@@ -1279,7 +1279,7 @@ describe('scheme', () => {
                 },
                 options: {
                     plugins: {
-                        'hapi-auth-cookie': {
+                        cookie: {
                             redirectTo: false
                         }
                     }


### PR DESCRIPTION
- Update `repository` field in `package.json`.
- Change route-level plugin options key from `hapi-auth-cookie` to `cookie`. I did it exactly like the `server.expose(...)` method does it by default: the plugin scope is removed ([documentation](https://hapi.dev/api/?v=20.1.0#-serverexposekey-value-options)). In this case `@hapi/cookie` becomes `cookie`.