### PR TITLE
Rename plugin options to be consistent across the hapi ecosystem

### DIFF
--- a/API.md
+++ b/API.md
@@ -5,7 +5,7 @@ Cookie authentication provides simple cookie-based session management. The user 
 authenticated via other means, typically a web form, and upon successful authentication
 the browser receives a reply with a session cookie. The cookie uses [Iron](https://github.com/hapijs/iron) to encrypt and sign the session content.
 
-Subsequent requests containing the session cookie are authenticated and validated via the provided `validateFunc` in case the cookie's encrypted content requires validation on each request.
+Subsequent requests containing the session cookie are authenticated and validated via the provided `validate` in case the cookie's encrypted content requires validation on each request.
 
 It is important to remember a couple of things:
 
@@ -41,7 +41,7 @@ The `'cookie`' scheme takes the following options:
     - set the `raw` property of the object to `true` to determine the current request path based on
       the raw node.js request object received from the HTTP server callback instead of the processed
       hapi request object
-- `async validateFunc` - an optional session validation function used to validate the content of the
+- `async validate` - an optional session validation function used to validate the content of the
   session cookie on each request. Used to verify that the internal session state is still valid
   (e.g. user account still exists). The function has the signature `function(request, session)`
   where:
@@ -49,7 +49,7 @@ The `'cookie`' scheme takes the following options:
     - `session` - is the session object set via `request.cookieAuth.set()`.
 
   Must return an object that contains:
-    - `valid` - `true` if the content of the session is valid, otherwise `false`.
+    - `isValid` - `true` if the content of the session is valid, otherwise `false`.
     - `credentials` - a credentials object passed back to the application in
       `request.auth.credentials`. If value is `null` or `undefined`, defaults to `session`. If
       set, will override the current cookie as if `request.cookieAuth.set()` was called.
@@ -141,16 +141,16 @@ internals.server = async function () {
 
         redirectTo: '/login',
 
-        validateFunc: async (request, session) => {
+        validate: async (request, session) => {
 
             const account = internals.users.find((user) => (user.id === session.id));
 
             if (!account) {
-                // Must return { valid: false } for invalid cookies
-                return { valid: false };
+                // Must return { isValid: false } for invalid cookies
+                return { isValid: false };
             }
 
-            return { valid: true, credentials: account };
+            return { isValid: true, credentials: account };
         }
     });
 

--- a/example/index.js
+++ b/example/index.js
@@ -97,14 +97,14 @@ internals.start = async function () {
             isSecure: false
         },
         redirectTo: '/login',
-        validateFunc: async (request, session) => {
+        validate: async (request, session) => {
 
             const cached = await cache.get(session.sid);
             const out = {
-                valid: !!cached
+                isValid: !!cached
             };
 
-            if (out.valid) {
+            if (out.isValid) {
                 out.credentials = cached.account;
             }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,7 +49,7 @@ internals.schema = Validate.object({
         .allow(false),
 
     requestDecoratorName: Validate.string().default('cookieAuth'),
-    validateFunc: Validate.func()
+    validate: Validate.func()
 })
     .required();
 
@@ -148,7 +148,7 @@ internals.implementation = (server, options) => {
                     return unauthenticated(Boom.unauthorized(null, 'cookie'));
                 }
 
-                if (!settings.validateFunc) {
+                if (!settings.validate) {
                     if (settings.keepAlive) {
                         h.state(settings.name, session);
                     }
@@ -159,12 +159,12 @@ internals.implementation = (server, options) => {
                 let credentials = session;
 
                 try {
-                    const result = await settings.validateFunc(request, session);
+                    const result = await settings.validate(request, session);
 
-                    Hoek.assert(typeof result === 'object', 'Invalid return from validateFunc');
-                    Hoek.assert(Object.prototype.hasOwnProperty.call(result, 'valid'), 'validateFunc must have valid property in return');
+                    Hoek.assert(typeof result === 'object', 'Invalid return from validate function');
+                    Hoek.assert(Object.prototype.hasOwnProperty.call(result, 'isValid'), 'validate function must have isValid property in return');
 
-                    if (!result.valid) {
+                    if (!result.isValid) {
                         throw Boom.unauthorized(null, 'cookie');
                     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -55,14 +55,14 @@ describe('scheme', () => {
         }).to.not.throw();
     });
 
-    it('fails if validateFunc is not a function', async () => {
+    it('fails if validate is not a function', async () => {
 
         const server = Hapi.server();
         await server.register(require('../'));
 
         expect(() => {
 
-            server.auth.strategy('session', 'cookie', { validateFunc: 'not a function' });
+            server.auth.strategy('session', 'cookie', { validate: 'not a function' });
         }).to.throw();
     });
 
@@ -95,13 +95,13 @@ describe('scheme', () => {
                 clearInvalid: true,
                 name: 'special'
             },
-            validateFunc: function (request, session) {
+            validate: function (request, session) {
 
                 const override = Hoek.clone(session);
                 override.something = 'new';
 
                 return {
-                    valid: session.user === 'valid',
+                    isValid: session.user === 'valid',
                     credentials: override
                 };
             }
@@ -157,13 +157,13 @@ describe('scheme', () => {
                 domain: 'example.com',
                 name: 'special'
             },
-            validateFunc: function (request, session) {
+            validate: function (request, session) {
 
                 const override = Hoek.clone(session);
                 override.something = 'new';
 
                 return {
-                    valid: session.user === 'valid',
+                    isValid: session.user === 'valid',
                     credentials: override
                 };
             }
@@ -209,13 +209,13 @@ describe('scheme', () => {
                 domain: 'example.com',
                 name: 'special'
             },
-            validateFunc: function (request, session) {
+            validate: function (request, session) {
 
                 const override = Hoek.clone(session);
                 override.something = 'new';
 
                 return {
-                    valid: session.user === 'valid',
+                    isValid: session.user === 'valid',
                     credentials: override
                 };
             }
@@ -270,13 +270,13 @@ describe('scheme', () => {
                 domain: 'example.com',
                 name: 'special'
             },
-            validateFunc: function (request, session) {
+            validate: function (request, session) {
 
                 const override = Hoek.clone(session);
                 override.something = 'new';
 
                 return {
-                    valid: session.user === 'valid',
+                    isValid: session.user === 'valid',
                     credentials: override
                 };
             }
@@ -311,13 +311,13 @@ describe('scheme', () => {
                 domain: 'example.com',
                 name: 'special'
             },
-            validateFunc: function (request, session) {
+            validate: function (request, session) {
 
                 const override = Hoek.clone(session);
                 override.something = 'new';
 
                 return {
-                    valid: session.user === 'valid',
+                    isValid: session.user === 'valid',
                     credentials: override
                 };
             }
@@ -383,7 +383,7 @@ describe('scheme', () => {
                 ttl: 60 * 1000,
                 name: 'special'
             },
-            validateFunc: function (request, session) {
+            validate: function (request, session) {
 
                 throw new Error('boom');
             }
@@ -442,7 +442,7 @@ describe('scheme', () => {
                 ttl: 60 * 1000,
                 name: 'first'
             },
-            validateFunc: function (request, session) {
+            validate: function (request, session) {
 
                 throw Boom.unauthorized(null, 'first');
             }
@@ -501,13 +501,13 @@ describe('scheme', () => {
                 domain: 'example.com',
                 name: 'special'
             },
-            validateFunc: function (request, session) {
+            validate: function (request, session) {
 
                 const override = Hoek.clone(session);
                 override.something = 'new';
 
                 return {
-                    valid: session.user === 'valid',
+                    isValid: session.user === 'valid',
                     credentials: override
                 };
             }
@@ -548,10 +548,10 @@ describe('scheme', () => {
                 path: '/example-path',
                 name: 'special'
             },
-            validateFunc: function (request, session) {
+            validate: function (request, session) {
 
                 return {
-                    valid: session.user === 'valid'
+                    isValid: session.user === 'valid'
                 };
             }
         });
@@ -587,10 +587,10 @@ describe('scheme', () => {
                 path: '/subpath',
                 name: 'special'
             },
-            validateFunc: function (request, session) {
+            validate: function (request, session) {
 
                 return {
-                    valid: session.user === 'valid'
+                    isValid: session.user === 'valid'
                 };
             }
         });
@@ -664,7 +664,7 @@ describe('scheme', () => {
         expect(header[0]).to.contain('Max-Age=60');
     });
 
-    it('extends ttl automatically (validateFunc)', async () => {
+    it('extends ttl automatically (validate)', async () => {
 
         const server = Hapi.server();
         await server.register(require('../'));
@@ -678,13 +678,13 @@ describe('scheme', () => {
                 name: 'special'
             },
             keepAlive: true,
-            validateFunc: function (request, session) {
+            validate: function (request, session) {
 
                 const override = Hoek.clone(session);
                 override.something = 'new';
 
                 return {
-                    valid: session.user === 'valid',
+                    isValid: session.user === 'valid',
                     credentials: override
                 };
             }


### PR DESCRIPTION
The hapi ecosystem offers the following official authentication plugins:

- **basic**: uses `validate` and `isValid` ([reference](https://hapi.dev/module/basic/api/?v=6.0.0#usage))
- **jwt**: uses `validate` and `isValid` ([reference](https://hapi.dev/module/jwt/api/?v=2.0.1#validate))
- **cookie**: uses `validateFunc` and `valid` ([reference](https://hapi.dev/module/cookie/api/?v=11.0.2#usage))
- **bell**:  does not use a validation function

This merge request aims to make these options consistent across all plugins.