### PR TITLE
Drop support for node v12 and hapi v18

### DIFF
--- a/.github/workflows/ci-plugin.yml
+++ b/.github/workflows/ci-plugin.yml
@@ -4,9 +4,12 @@ on:
   push:
     branches:
       - master
+      - v12
   pull_request:
   workflow_dispatch:
 
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-plugin.yml@master
+    with:
+      min-node-version: 14

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
-Copyright (c) 2012-2020, Sideway Inc, and project contributors  
-Copyright (c) 2012-2014, Walmart.  
+Copyright (c) 2012-2022, Sideway Inc, and project contributors
+Copyright (c) 2012-2014, Walmart.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ const internals = {};
 module.exports = {
     pkg: require('../package.json'),
     requirements: {
-        hapi: '>=18.4.0'
+        hapi: '>=19.0.0'
     },
     register: (server, options) => {
 


### PR DESCRIPTION
In dropping node v12 we should also drop support for hapi v18, which only supported up to node v12.