### PR TITLE
Support for hapi v21, node v18, ESM tests

### DIFF
--- a/.github/workflows/ci-plugin.yml
+++ b/.github/workflows/ci-plugin.yml
@@ -10,3 +10,6 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-plugin.yml@master
+    with:
+      min-node-version: 14
+      min-hapi-version: 20

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,6 @@
-Copyright (c) 2012-2020, Sideway Inc, and project contributors  
-Copyright (c) 2012-2014, Walmart.  
+Copyright (c) 2012-2022, Project contributors
+Copyright (c) 2012-2020, Sideway Inc
+Copyright (c) 2012-2014, Walmart.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,12 +9,12 @@ const Validate = require('@hapi/validate');
 const internals = {};
 
 
-module.exports = {
+exports.plugin = {
     pkg: require('../package.json'),
     requirements: {
-        hapi: '>=18.4.0'
+        hapi: '>=20.0.0'
     },
-    register: (server, options) => {
+    register: (server) => {
 
         server.auth.scheme('cookie', internals.implementation);
     }
@@ -168,7 +168,7 @@ internals.implementation = (server, options) => {
                         throw Boom.unauthorized(null, 'cookie');
                     }
 
-                    credentials = result.credentials || credentials;
+                    credentials = result.credentials ?? credentials;
 
                     if (settings.keepAlive) {
                         h.state(settings.name, session);
@@ -196,9 +196,7 @@ internals.implementation = (server, options) => {
             const unauthenticated = (err, result) => {
 
                 let redirectTo = settings.redirectTo;
-                if (request.route.settings.plugins.cookie &&
-                    request.route.settings.plugins.cookie.redirectTo !== undefined) {
-
+                if (request.route.settings.plugins.cookie?.redirectTo !== undefined) {
                     redirectTo = request.route.settings.plugins.cookie.redirectTo;
                 }
 

--- a/package.json
+++ b/package.json
@@ -20,16 +20,16 @@
     ]
   },
   "dependencies": {
-    "@hapi/boom": "9.x.x",
-    "@hapi/bounce": "2.x.x",
-    "@hapi/hoek": "9.x.x",
-    "@hapi/validate": "1.x.x"
+    "@hapi/boom": "^10.0.0",
+    "@hapi/bounce": "^3.0.0",
+    "@hapi/hoek": "^10.0.0",
+    "@hapi/validate": "^2.0.0"
   },
   "devDependencies": {
-    "@hapi/code": "8.x.x",
-    "@hapi/eslint-plugin": "*",
-    "@hapi/hapi": "20.x.x",
-    "@hapi/lab": "24.x.x"
+    "@hapi/code": "^9.0.0",
+    "@hapi/eslint-plugin": "^6.0.0",
+    "@hapi/hapi": "^21.0.0-beta.1",
+    "@hapi/lab": "^25.0.1"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L",

--- a/test/esm.js
+++ b/test/esm.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+
+
+const { before, describe, it } = exports.lab = Lab.script();
+const expect = Code.expect;
+
+
+describe('import()', () => {
+
+    let Cookie;
+
+    before(async () => {
+
+        Cookie = await import('../lib/index.js');
+    });
+
+    it('exposes all methods and classes as named imports', () => {
+
+        expect(Object.keys(Cookie)).to.equal([
+            'default',
+            'plugin'
+        ]);
+    });
+});


### PR DESCRIPTION
 - Support and test on hapi v21, drop support for hapi v19.
 - Support and test on node v18, utilize some newer JS syntax.
 - Update all deps for node v18 and hapi v21.
 - Test ESM support.
 - Ensure the module has a `plugin` export, consistent with other hapijs org plugins.

If this looks good, this will be the final addition to cookie v12.